### PR TITLE
Add possibility to use different repo version

### DIFF
--- a/beats/repository.sls
+++ b/beats/repository.sls
@@ -1,4 +1,4 @@
-{%- set version = pillar.get('beats:version', '5') %}
+{%- set version = salt['pillar.get']('beats:version', '5') %}
 {% if salt['grains.get']('os_family') == 'Debian' %}
 
 add_elastic_repository:

--- a/beats/repository.sls
+++ b/beats/repository.sls
@@ -1,3 +1,4 @@
+{%- set version = pillar.get('beats:version', '5') %}
 {% if salt['grains.get']('os_family') == 'Debian' %}
 
 add_elastic_repository:
@@ -5,7 +6,7 @@ add_elastic_repository:
         - name: apt-transport-https
 
     pkgrepo.managed:
-        - name: deb https://artifacts.elastic.co/packages/5.x/apt stable main
+        - name: deb https://artifacts.elastic.co/packages/' ~ {{ version }} ~ '.x/apt stable main
         - file: /etc/apt/sources.list.d/elastic.list
         - gpgcheck: 1
         - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
@@ -17,8 +18,8 @@ add_elastic_repository:
 add_elastic_repository:
     pkgrepo.managed:
         - name: elastic
-        - humanname: "Elastic repository for 5.x packages"
-        - baseurl: https://artifacts.elastic.co/packages/5.x/yum
+        - humanname: "Elastic repository for ' ~ {{ version }} ~ '.x packages"
+        - baseurl: https://artifacts.elastic.co/packages/' ~ {{ version }} ~ '.x/yum
         - gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
         - gpgcheck: 1
         - disabled: False

--- a/beats/repository.sls
+++ b/beats/repository.sls
@@ -6,7 +6,7 @@ add_elastic_repository:
         - name: apt-transport-https
 
     pkgrepo.managed:
-        - name: deb https://artifacts.elastic.co/packages/' ~ {{ version }} ~ '.x/apt stable main
+        - name: deb https://artifacts.elastic.co/packages/{{ version }}.x/apt stable main
         - file: /etc/apt/sources.list.d/elastic.list
         - gpgcheck: 1
         - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
@@ -18,8 +18,8 @@ add_elastic_repository:
 add_elastic_repository:
     pkgrepo.managed:
         - name: elastic
-        - humanname: "Elastic repository for ' ~ {{ version }} ~ '.x packages"
-        - baseurl: https://artifacts.elastic.co/packages/' ~ {{ version }} ~ '.x/yum
+        - humanname: "Elastic repository for " ~ {{ version }} ~ ".x packages"
+        - baseurl: https://artifacts.elastic.co/packages/{{ version }}.x/yum
         - gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
         - gpgcheck: 1
         - disabled: False

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 beats:
+    version: 6
     filebeat:
         config:
             filebeat.prospectors:


### PR DESCRIPTION
This PR adds the version pillar. You can pin to version 6 if needed.
Only tested on debian.