### PR TITLE
journalbeat: fix pillar merge in map.jinja

### DIFF
--- a/beats/community/journalbeat/map.jinja
+++ b/beats/community/journalbeat/map.jinja
@@ -8,6 +8,6 @@
         'hash': 'e1b96dc988270624ecfc6cbe590f9890'
     },
 },
-merge=salt['pillar.get']('beats.community.journalbeat:config', {}),
+merge=salt['pillar.get']('beats:community:journalbeat', {}),
 default='default')
 %}


### PR DESCRIPTION
Merging pillar with map.jinja didn't work before.
This is needed to download journalbeat from a different source since github doesn't allow too many downloads.