### PR TITLE
fix escaping in pkgrepo humanname value

### DIFF
--- a/beats/repository.sls
+++ b/beats/repository.sls
@@ -23,7 +23,7 @@ add_elastic_repository:
 add_elastic_repository:
     pkgrepo.{{ repo_state }}:
         - name: elastic
-        - humanname: "Elastic repository for " ~ {{ version }} ~ ".x packages"
+        - humanname: "Elastic repository for {{ version }}.x packages"
         - baseurl: https://artifacts.elastic.co/packages/{{ version }}.x/yum
         - gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
         - gpgcheck: 1


### PR DESCRIPTION
State failed because of unnecessary escaping.

Testet on CentOS 7.4

`salt-call state.sls beats.repository`